### PR TITLE
Fix asset serving, auth parsing, and message positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed path traversal vulnerability in asset serving
+- Fixed Drupal asset route not matching nested paths (e.g. `icons/favicon.png`)
+- Fixed basic auth users never being parsed from `TIDY_FEEDBACK_USERS` env var
+- Added inline style fallback on message element for when CSS hasn't loaded yet
 - [PR-28](https://github.com/itk-dev/tidy-feedback/pull/28)
   27: Cleaned up code
 - Replaced Bootstrap with CoreUI and modernized SCSS imports (`@import` → `@use`)

--- a/drupal/tidy_feedback.routing.yml
+++ b/drupal/tidy_feedback.routing.yml
@@ -25,6 +25,7 @@ tidy_feedback_asset:
     methods: [GET]
     requirements:
         _permission: "access content"
+        asset: ".+"
 
 tidy_feedback_show:
     path: "/tidy-feedback/{id}"

--- a/src/TidyFeedbackHelper.php
+++ b/src/TidyFeedbackHelper.php
@@ -148,9 +148,13 @@ final class TidyFeedbackHelper implements EventSubscriberInterface
 
     public function createAssetResponse(string $asset): Response
     {
-        $filename = self::ASSET_PATH.'/'.$asset;
+        $buildDir = realpath(self::ASSET_PATH);
+        if (false === $buildDir) {
+            throw new NotFoundHttpException();
+        }
 
-        if (!is_readable($filename)) {
+        $filename = realpath(self::ASSET_PATH.'/'.$asset);
+        if (false === $filename || !str_starts_with($filename, $buildDir.'/')) {
             throw new NotFoundHttpException();
         }
 
@@ -217,7 +221,7 @@ final class TidyFeedbackHelper implements EventSubscriberInterface
 
             if ($users = $getEnv('TIDY_FEEDBACK_USERS')) {
                 try {
-                    $config[self::CONFIG_USERS] = json_decode($users, true, flags: JSON_THROW_ON_ERROR);
+                    self::$config[self::CONFIG_USERS] = json_decode($users, true, flags: JSON_THROW_ON_ERROR);
                 } catch (\Throwable) {
                 }
             }

--- a/templates/widget.html.twig
+++ b/templates/widget.html.twig
@@ -21,7 +21,8 @@
         <script {{ capture_exclude_attributes|raw }} src="{{ path('tidy_feedback_asset', {asset: 'widget.js'}) }}"
                                                      data-tidy-feedback-config="{{ config|json_encode }} "></script>
         <div class="tidy-feedback" {{ capture_exclude_attributes|raw }}>
-            <div {{ capture_exclude_attributes|raw }} hidden class="tidy-feedback-message"></div>
+            <div {{ capture_exclude_attributes|raw }} hidden class="tidy-feedback-message"
+                 style="position:fixed;top:0.5em;left:50%;transform:translateX(-50%);z-index:10002"></div>
             <button {{ capture_exclude_attributes|raw }} hidden type="button" class="tidy-feedback-start"
                                                          data-tidy-feedback-action="start">{{ 'Feedback'|trans }}</button>
 


### PR DESCRIPTION
## Summary

- Prevent path traversal in `createAssetResponse()` by validating resolved paths stay within the build directory using `realpath()`
- Add `asset: ".+"` requirement to Drupal route so nested asset paths (e.g. `icons/favicon.png`) are matched correctly
- Fix `$config` → `self::$config` typo that caused `TIDY_FEEDBACK_USERS` env var to be parsed into a local variable and discarded
- Add inline style fallback on message div for when Shadow DOM CSS hasn't loaded yet

Closes #29, closes #31

## Test plan

- [ ] Visit a page with the widget — confirm the "Feedback" button appears styled
- [ ] Open form, submit feedback — confirm the "Feedback created" message appears at the top center
- [ ] Check browser DevTools Network tab: asset requests (`widget.css`, `widget.js`) return 200
- [ ] Attempt path traversal (`/tidy-feedback/asset/../../composer.json`) — should return 404
- [ ] Set `TIDY_FEEDBACK_USERS={"admin":"password"}` and verify basic auth works on `/tidy-feedback`