### PR TITLE
Issue #45: Clean up the testing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Cleaned up test page: removed debug styles, test button, stale commented-out code, and fixed typo
 - Added optional caching for translations and Twig compilation via `TIDY_FEEDBACK_CACHE_DIR`
 - Added collapsible list of existing feedback items in widget form
 - Added feedback count badge on start button when feedback exists for the current page

--- a/templates/test.html.twig
+++ b/templates/test.html.twig
@@ -3,17 +3,9 @@
 {% block title 'Tidy feedback test'|trans %}
 
 {% block content %}
-    <style>
-        button {
-            outline: dotted 10px orange;
-        }
-    </style>
-
-    <button>x</button>
-
     <h1>{{ block('title') }}</h1>
 
-    <p>This is a <strong>tset</strong>!</p>
+    <p>This is a <strong>test</strong>!</p>
 
     {% for i in range(1, 99) %}
         <section>
@@ -22,27 +14,4 @@
             <p></p>
         </section>
     {% endfor %}
-
-    {#
-    <style>
-        .tidy-feedback-region {
-            left: 100px;
-            top: 100px;
-
-            width: 20em;
-            height: 5em;
-
-            padding: 1em;
-        }
-    </style>
-
-    <div class="tidy-feedback-select-region">
-        <div class="tidy-feedback-region">
-            This is a fake region …
-            {% for s in ['nw', 'ne', 'sw', 'se'] %}
-                <div class="handle handle-{{ s }}"></div>
-            {% endfor %}
-        </div>
-    </div>
-    #}
 {% endblock %}


### PR DESCRIPTION
## Summary
- Cleaned up the test page by removing debug artifacts and stale code

## Changes
- Removed `<style>button { outline: dotted 10px orange; }</style>` debug block
- Removed test `<button>x</button>` element
- Fixed "tset" typo to "test"
- Removed commented-out region HTML block (lines 26-47)
- Updated CHANGELOG.md

## Testing
- Twig coding standards pass (`task coding-standards:twig:check`)
- Visual inspection of the template confirms only intended content remains

Fixes #45