### PR TITLE
fix: add cache pruning for stale translation cache entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added cache pruning for stale translation cache entries with 1-week TTL
 - Added rounded corners and border when widget is dragged away from window edge, removed when pushed against edge
 - Removed unused `subject`, `status`, and `category` fields from Item entity, admin templates, and translations
 - Fixed highlighted region losing its dashed border after submitting feedback

--- a/src/TidyFeedbackHelper.php
+++ b/src/TidyFeedbackHelper.php
@@ -109,7 +109,7 @@ final class TidyFeedbackHelper implements EventSubscriberInterface
                 $maxMtime = max(array_map('filemtime', $translationFiles));
                 $cacheKey = 'translations_'.$maxMtime;
 
-                $cache = new FilesystemAdapter('tidy_feedback', 0, $cacheDir);
+                $cache = new FilesystemAdapter('tidy_feedback', 604800, $cacheDir);
                 $item = $cache->getItem($cacheKey);
 
                 if ($item->isHit()) {
@@ -121,6 +121,7 @@ final class TidyFeedbackHelper implements EventSubscriberInterface
                 self::$translations = $this->parseTranslationFiles($translationFiles);
                 $item->set(self::$translations);
                 $cache->save($item);
+                $cache->prune();
             } else {
                 self::$translations = $this->parseTranslationFiles($translationFiles ?: []);
             }


### PR DESCRIPTION
## Summary

- Changed `FilesystemAdapter` TTL from `0` (infinite) to `604800` (1 week) so stale translation cache entries expire automatically
- Added `$cache->prune()` call after saving a new cache entry to immediately clean up expired items

Closes #41

## Test plan

- [ ] Verify translations still work correctly (cache hit path)
- [ ] Change a translation file and verify the new translation is picked up (cache miss path with new key)
- [ ] Confirm old cache entries in the `tidy_feedback` cache directory are cleaned up after the TTL expires