### PR TITLE
docs: add CLAUDE.md, API docs, workflow diagram, and architecture overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Workflow diagram, API documentation, data schema, and architecture overview in README
+- Project-level CLAUDE.md with development guide and conventions
 - Auto-focus on description textarea after selecting an element
 - 20px padding around highlight region so small elements aren't obscured by corner handles
 - Keyboard shortcuts: Shift+C to start feedback, Ctrl/Cmd+Enter to submit, Escape to cancel

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,110 @@
+# Tidy Feedback - Project Guide
+
+## Project description
+
+Tidy feedback is a **dual-framework library** that works as both a
+[Drupal module](https://www.drupal.org/docs/user_guide/en/understanding-modules.html) and a
+[Symfony bundle](https://symfony.com/doc/current/bundles.html). It provides a user feedback widget that is automatically
+injected into every HTML page via a kernel response listener. Users can highlight a page element, fill in a form, and
+submit feedback with an auto-captured screenshot.
+
+## Architecture
+
+### Shared trait pattern
+
+The core controller logic lives in `src/Controller/TidyFeedbackControllerTrait.php` — a PHP trait that is consumed by
+both the Drupal controller (`drupal/src/Controller/TidyFeedbackController.php`) and the Symfony controller
+(`symfony/src/Controller/TidyFeedbackController.php`). This avoids duplicating business logic across frameworks.
+
+### Separate entity manager
+
+Tidy feedback uses its **own Doctrine entity manager**, configured via `TIDY_FEEDBACK_DATABASE_URL`. This keeps feedback
+data isolated from the host application's database and avoids conflicts with Drupal's or Symfony's default entity
+manager.
+
+### Shadow DOM
+
+The widget renders inside a
+[Shadow DOM](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_shadow_DOM) to isolate its styles
+from the host page.
+
+## Key directories and files
+
+| Path | Description |
+|---|---|
+| `src/` | Shared PHP code (controller trait, entity, helper) |
+| `symfony/src/` | Symfony bundle (controller, bundle class) |
+| `drupal/` | Drupal module (controller, routing, info.yml) |
+| `assets/` | JavaScript and CSS source files |
+| `assets/component/` | Reusable JS components (draggable, region) |
+| `build/` | Compiled assets (committed to repo) |
+| `templates/` | Twig templates (widget, admin list, detail) |
+| `translations/` | Translation YAML files |
+| `resources/config/routes/` | Route config templates for installation |
+| `webpack.config.js` | Webpack Encore configuration |
+| `Taskfile.yml` | Task runner commands |
+| `compose.yaml` | Docker Compose services |
+
+## Build commands
+
+```shell
+# Build assets for production (via Docker)
+task assets:build
+
+# Or run Encore directly (requires local Node.js)
+npx encore dev
+npx encore production
+```
+
+The compiled `build/` directory is committed to the repository so that consumers do not need a Node.js build step.
+
+## Development environment
+
+```shell
+# Start the Symfony dev app with Tidy feedback installed
+task app:start
+
+# Open the test page in a browser
+task app:open
+
+# Stop the app
+task app:stop
+```
+
+The test page is available at `/tidy-feedback/test` on the running app.
+
+## Coding standards
+
+```shell
+# Apply all coding standards (PHP, JS, Markdown, YAML, Twig, Composer)
+task coding-standards:apply
+
+# Check all coding standards
+task coding-standards:check
+```
+
+Individual standard categories can be run separately, e.g. `task coding-standards:php:apply`.
+
+## Testing
+
+There is currently no automated test suite. Testing is manual via the `/tidy-feedback/test` page in the dev app.
+
+## Translation workflow
+
+```shell
+# Extract translation strings and format YAML
+task translations:extract
+```
+
+Translation files live in `translations/` and use `{domain}.{locale}.yaml` naming.
+
+## Conventions
+
+- **Shadow DOM**: The widget is isolated inside a Shadow DOM — all widget CSS must be scoped accordingly.
+- **Compiled `build/` committed**: Always rebuild assets (`task assets:build`) and commit the `build/` directory when
+  changing anything in `assets/`.
+- **Environment variable prefix**: All configuration uses the `TIDY_FEEDBACK_` prefix.
+- **Separate entity manager**: The module manages its own Doctrine connection — do not use the host app's entity
+  manager.
+- **Dual-framework support**: Changes to controller logic go in the shared trait (`TidyFeedbackControllerTrait`), not
+  in the framework-specific controllers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,20 +30,20 @@ from the host page.
 
 ## Key directories and files
 
-| Path | Description |
-|---|---|
-| `src/` | Shared PHP code (controller trait, entity, helper) |
-| `symfony/src/` | Symfony bundle (controller, bundle class) |
-| `drupal/` | Drupal module (controller, routing, info.yml) |
-| `assets/` | JavaScript and CSS source files |
-| `assets/component/` | Reusable JS components (draggable, region) |
-| `build/` | Compiled assets (committed to repo) |
-| `templates/` | Twig templates (widget, admin list, detail) |
-| `translations/` | Translation YAML files |
-| `resources/config/routes/` | Route config templates for installation |
-| `webpack.config.js` | Webpack Encore configuration |
-| `Taskfile.yml` | Task runner commands |
-| `compose.yaml` | Docker Compose services |
+| Path                       | Description                                      |
+|----------------------------|--------------------------------------------------|
+| `src/`                     | Shared PHP code (controller trait, entity, helper) |
+| `symfony/src/`             | Symfony bundle (controller, bundle class)         |
+| `drupal/`                  | Drupal module (controller, routing, info.yml)     |
+| `assets/`                  | JavaScript and CSS source files                   |
+| `assets/component/`        | Reusable JS components (draggable, region)        |
+| `build/`                   | Compiled assets (committed to repo)               |
+| `templates/`               | Twig templates (widget, admin list, detail)       |
+| `translations/`            | Translation YAML files                            |
+| `resources/config/routes/` | Route config templates for installation           |
+| `webpack.config.js`        | Webpack Encore configuration                      |
+| `Taskfile.yml`             | Task runner commands                              |
+| `compose.yaml`             | Docker Compose services                           |
 
 ## Build commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,20 +30,20 @@ from the host page.
 
 ## Key directories and files
 
-| Path                       | Description                                      |
-|----------------------------|--------------------------------------------------|
+| Path                       | Description                                        |
+|----------------------------|----------------------------------------------------|
 | `src/`                     | Shared PHP code (controller trait, entity, helper) |
-| `symfony/src/`             | Symfony bundle (controller, bundle class)         |
-| `drupal/`                  | Drupal module (controller, routing, info.yml)     |
-| `assets/`                  | JavaScript and CSS source files                   |
-| `assets/component/`        | Reusable JS components (draggable, region)        |
-| `build/`                   | Compiled assets (committed to repo)               |
-| `templates/`               | Twig templates (widget, admin list, detail)       |
-| `translations/`            | Translation YAML files                            |
-| `resources/config/routes/` | Route config templates for installation           |
-| `webpack.config.js`        | Webpack Encore configuration                      |
-| `Taskfile.yml`             | Task runner commands                              |
-| `compose.yaml`             | Docker Compose services                           |
+| `symfony/src/`             | Symfony bundle (controller, bundle class)          |
+| `drupal/`                  | Drupal module (controller, routing, info.yml)      |
+| `assets/`                  | JavaScript and CSS source files                    |
+| `assets/component/`        | Reusable JS components (draggable, region)         |
+| `build/`                   | Compiled assets (committed to repo)                |
+| `templates/`               | Twig templates (widget, admin list, detail)        |
+| `translations/`            | Translation YAML files                             |
+| `resources/config/routes/` | Route config templates for installation            |
+| `webpack.config.js`        | Webpack Encore configuration                       |
+| `Taskfile.yml`             | Task runner commands                               |
+| `compose.yaml`             | Docker Compose services                            |
 
 ## Build commands
 

--- a/README.md
+++ b/README.md
@@ -165,14 +165,14 @@ TIDY_FEEDBACK_USERS={"admin": "s3cret", "reviewer": "p4ssw0rd"}
 
 All paths are relative to the Tidy feedback prefix (default `/tidy-feedback`).
 
-| Method | Path             | Description                  | Auth required            | Response     |
-|--------|------------------|------------------------------|--------------------------|--------------|
+| Method | Path             | Description                  | Auth required             | Response     |
+|--------|------------------|------------------------------|---------------------------|--------------|
 | `GET`  | `/`              | List all feedback items      | Yes (if users configured) | HTML or JSON |
-| `POST` | `/`              | Create a new feedback item   | No                       | JSON (201)   |
-| `GET`  | `/check`         | Get feedback count for a URL | No                       | JSON         |
+| `POST` | `/`              | Create a new feedback item   | No                        | JSON (201)   |
+| `GET`  | `/check`         | Get feedback count for a URL | No                        | JSON         |
 | `GET`  | `/{id}`          | Show a single feedback item  | Yes (if users configured) | HTML or JSON |
 | `GET`  | `/{id}/image`    | Get the screenshot image     | Yes (if users configured) | Binary image |
-| `GET`  | `/asset/{asset}` | Serve a compiled asset       | No                       | Binary file  |
+| `GET`  | `/asset/{asset}` | Serve a compiled asset       | No                        | Binary file  |
 
 Append `?_format=json` to `GET /` or `GET /{id}` to force JSON output.
 
@@ -180,12 +180,12 @@ Append `?_format=json` to `GET /` or `GET /{id}` to force JSON output.
 
 Create a new feedback item by sending a JSON body:
 
-| Field         | Type                | Description                                         |
-|---------------|---------------------|-----------------------------------------------------|
-| `created_by`  | `string` (optional) | Email address of the submitter                      |
-| `email`       | `string` (optional) | Email address (stored in data)                      |
-| `description` | `string`            | Feedback description                                |
-| `image`       | `string`            | Screenshot as a data URI                            |
+| Field         | Type                | Description                                          |
+|---------------|---------------------|------------------------------------------------------|
+| `created_by`  | `string` (optional) | Email address of the submitter                       |
+| `email`       | `string` (optional) | Email address (stored in data)                       |
+| `description` | `string`            | Feedback description                                 |
+| `image`       | `string`            | Screenshot as a data URI                             |
 | `context`     | `object`            | Page context (URL, viewport, selected element, etc.) |
 
 Example 201 response:
@@ -205,8 +205,8 @@ Example 201 response:
 
 Returns the feedback count and a summary of items for a given URL.
 
-| Parameter | Type             | Description          |
-|-----------|------------------|----------------------|
+| Parameter | Type             | Description           |
+|-----------|------------------|-----------------------|
 | `url`     | `string` (query) | The page URL to check |
 
 Example response:

--- a/README.md
+++ b/README.md
@@ -93,23 +93,38 @@ which isolates its styles from the host page. The user-facing workflow is:
 
 1. A "Feedback" button appears on the right side of the page
 2. Clicking it opens a form with a draggable region overlay for highlighting a part of the page
-3. The user fills in subject, email, and description fields
+3. The user fills in email and description fields
 4. On submit, a screenshot is captured automatically using [snapdom](https://github.com/zumerlab/snapdom)
 5. The screenshot, form data, and page context (URL, viewport size, etc.) are sent to the server
+
+```mermaid
+flowchart TD
+    A[Page loads] --> B[Kernel listener injects widget before closing body tag]
+    B --> C[Start button appears]
+    C --> D{User clicks + or presses Shift+C}
+    D --> E[Select mode: crosshair cursor highlights elements on hover]
+    E --> F[User clicks an element]
+    F --> G[Region overlay positioned with 20px padding]
+    G --> H[Form shown, description field focused]
+    H --> I[User submits via button or Ctrl/Cmd+Enter]
+    I --> J[Screenshot captured via snapdom]
+    J --> K[POST JSON to server]
+    K --> L[Item entity created, 201 response]
+    L --> M[Success message, form reset, count badge refreshed]
+```
 
 ## Query string parameters
 
 You can use query string parameters to control the widget:
 
 - `tidy-feedback-show=form` — automatically open the feedback form when the page loads
-- `tidy-feedback[subject]=...` — pre-fill the subject field
 - `tidy-feedback[email]=...` — pre-fill (and lock) the email field
 - `tidy-feedback[description]=...` — pre-fill the description field
 
 Example:
 
 ``` plain
-/my-page?tidy-feedback-show=form&tidy-feedback[subject]=Bug%20report&tidy-feedback[email]=user@example.com
+/my-page?tidy-feedback-show=form&tidy-feedback[email]=user@example.com
 ```
 
 ## Disabling the widget
@@ -146,6 +161,90 @@ set `TIDY_FEEDBACK_USERS` to a JSON object mapping usernames to passwords:
 TIDY_FEEDBACK_USERS={"admin": "s3cret", "reviewer": "p4ssw0rd"}
 ```
 
+## API endpoints
+
+All paths are relative to the Tidy feedback prefix (default `/tidy-feedback`).
+
+| Method | Path | Description | Auth required | Response |
+|--------|------|-------------|---------------|----------|
+| `GET` | `/` | List all feedback items | Yes (if users configured) | HTML or JSON |
+| `POST` | `/` | Create a new feedback item | No | JSON (201) |
+| `GET` | `/check` | Get feedback count for a URL | No | JSON |
+| `GET` | `/{id}` | Show a single feedback item | Yes (if users configured) | HTML or JSON |
+| `GET` | `/{id}/image` | Get the screenshot image | Yes (if users configured) | Binary image |
+| `GET` | `/asset/{asset}` | Serve a compiled asset | No | Binary file |
+
+Append `?_format=json` to `GET /` or `GET /{id}` to force JSON output.
+
+### POST /
+
+Create a new feedback item by sending a JSON body:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `created_by` | `string` (optional) | Email address of the submitter |
+| `email` | `string` (optional) | Email address (stored in data) |
+| `description` | `string` | Feedback description |
+| `image` | `string` | Screenshot as a data URI |
+| `context` | `object` | Page context (URL, viewport, selected element, etc.) |
+
+Example 201 response:
+
+``` json
+{
+  "data": {
+    "id": 42,
+    "createdAt": "2025-07-10T12:00:00+00:00",
+    "createdBy": "user@example.com",
+    "data": { "..." }
+  }
+}
+```
+
+### GET /check
+
+Returns the feedback count and a summary of items for a given URL.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `url` | `string` (query) | The page URL to check |
+
+Example response:
+
+``` json
+{
+  "data": {
+    "count": 3,
+    "items": [
+      {
+        "description": "Button is misaligned",
+        "url": "/tidy-feedback/42",
+        "selectedElement": "div.main > button.submit"
+      }
+    ]
+  }
+}
+```
+
+### Data schema
+
+The `data` JSON column on each Item entity stores the full feedback payload:
+
+``` json
+{
+  "email": "user@example.com",
+  "description": "The heading overlaps the sidebar",
+  "image": "data:image/svg+xml,...",
+  "context": {
+    "url": "https://example.com/page",
+    "viewport": { "width": 1920, "height": 1080 },
+    "selectedElement": "div.content > h1",
+    "region": { "top": 100, "left": 50, "width": 400, "height": 200 }
+  },
+  "created_by": "user@example.com"
+}
+```
+
 ## All configuration options
 
 Only `TIDY_FEEDBACK_DATABASE_URL` is required.
@@ -171,6 +270,22 @@ query string will *not* be included.
 ``` shell
 task
 ```
+
+### Architecture
+
+Tidy feedback is designed to work as both a Drupal module and a Symfony bundle from a single codebase. The key design
+patterns are:
+
+- **Shared trait**: The controller logic lives in `TidyFeedbackControllerTrait` (`src/Controller/`). Both the Drupal and
+  Symfony controllers consume this trait, avoiding code duplication.
+- **Separate entity manager**: The module creates its own Doctrine `EntityManager` configured via
+  `TIDY_FEEDBACK_DATABASE_URL`, keeping feedback data isolated from the host application's database.
+- **Kernel listener**: `TidyFeedbackHelper` implements `EventSubscriberInterface` and listens on `kernel.response` to
+  inject the widget HTML before the closing `</body>` tag.
+- **Shadow DOM isolation**: The widget renders inside a Shadow DOM so its styles never leak into (or are affected by)
+  the host page.
+- **Watered-down Twig**: The helper instantiates a minimal Twig environment with only a `trans` filter and a `path`
+  function, independent of the host framework's template engine.
 
 ### composer.json
 
@@ -232,7 +347,6 @@ For easy testing, you can use [Bookmarklet Creator](https://mrcoles.com/bookmark
 ``` javascript
 const url = new URL(document.location);
 url.searchParams.set('tidy-feedback-show', 'form');
-url.searchParams.set('tidy-feedback[subject]', 'My feedback '+new Date().toISOString());
 url.searchParams.set('tidy-feedback[email]', 'test@example.com');
 url.searchParams.set('tidy-feedback[description]', 'This is cool!');
 document.location = url

--- a/README.md
+++ b/README.md
@@ -165,14 +165,14 @@ TIDY_FEEDBACK_USERS={"admin": "s3cret", "reviewer": "p4ssw0rd"}
 
 All paths are relative to the Tidy feedback prefix (default `/tidy-feedback`).
 
-| Method | Path | Description | Auth required | Response |
-|--------|------|-------------|---------------|----------|
-| `GET` | `/` | List all feedback items | Yes (if users configured) | HTML or JSON |
-| `POST` | `/` | Create a new feedback item | No | JSON (201) |
-| `GET` | `/check` | Get feedback count for a URL | No | JSON |
-| `GET` | `/{id}` | Show a single feedback item | Yes (if users configured) | HTML or JSON |
-| `GET` | `/{id}/image` | Get the screenshot image | Yes (if users configured) | Binary image |
-| `GET` | `/asset/{asset}` | Serve a compiled asset | No | Binary file |
+| Method | Path             | Description                  | Auth required            | Response     |
+|--------|------------------|------------------------------|--------------------------|--------------|
+| `GET`  | `/`              | List all feedback items      | Yes (if users configured) | HTML or JSON |
+| `POST` | `/`              | Create a new feedback item   | No                       | JSON (201)   |
+| `GET`  | `/check`         | Get feedback count for a URL | No                       | JSON         |
+| `GET`  | `/{id}`          | Show a single feedback item  | Yes (if users configured) | HTML or JSON |
+| `GET`  | `/{id}/image`    | Get the screenshot image     | Yes (if users configured) | Binary image |
+| `GET`  | `/asset/{asset}` | Serve a compiled asset       | No                       | Binary file  |
 
 Append `?_format=json` to `GET /` or `GET /{id}` to force JSON output.
 
@@ -180,13 +180,13 @@ Append `?_format=json` to `GET /` or `GET /{id}` to force JSON output.
 
 Create a new feedback item by sending a JSON body:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `created_by` | `string` (optional) | Email address of the submitter |
-| `email` | `string` (optional) | Email address (stored in data) |
-| `description` | `string` | Feedback description |
-| `image` | `string` | Screenshot as a data URI |
-| `context` | `object` | Page context (URL, viewport, selected element, etc.) |
+| Field         | Type                | Description                                         |
+|---------------|---------------------|-----------------------------------------------------|
+| `created_by`  | `string` (optional) | Email address of the submitter                      |
+| `email`       | `string` (optional) | Email address (stored in data)                      |
+| `description` | `string`            | Feedback description                                |
+| `image`       | `string`            | Screenshot as a data URI                            |
+| `context`     | `object`            | Page context (URL, viewport, selected element, etc.) |
 
 Example 201 response:
 
@@ -205,9 +205,9 @@ Example 201 response:
 
 Returns the feedback count and a summary of items for a given URL.
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `url` | `string` (query) | The page URL to check |
+| Parameter | Type             | Description          |
+|-----------|------------------|----------------------|
+| `url`     | `string` (query) | The page URL to check |
 
 Example response:
 


### PR DESCRIPTION
## Summary

- Create project-level `CLAUDE.md` with development guide, architecture notes, build commands, and conventions
- Add Mermaid workflow diagram to README showing the full feedback flow
- Add API endpoints documentation (table + POST / and GET /check details + data schema)
- Add Architecture subsection under Development explaining the shared trait pattern
- Fix stale references to removed `subject` field in query string params and bookmarklet

## Test plan

- [ ] Verify Mermaid diagram renders correctly on GitHub
- [ ] Review API endpoint documentation against actual controller code
- [ ] Confirm markdownlint passes (`task coding-standards:markdown:check`)
- [ ] Review CLAUDE.md accuracy against project structure