### PR TITLE
test: add PHPUnit and Vitest automated test suites

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,33 @@
+name: Tests
+
+on:
+    pull_request:
+    push:
+        branches:
+            - main
+            - develop
+
+jobs:
+    php-tests:
+        name: PHP tests
+        runs-on: ubuntu-latest
+        env:
+            COMPOSE_USER: root
+        steps:
+            - uses: actions/checkout@v4
+            - run: |
+                  docker network create frontend
+                  docker compose run --rm phpfpm composer install
+                  docker compose run --rm phpfpm vendor/bin/phpunit
+
+    js-tests:
+        name: JavaScript tests
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 24
+                  cache: npm
+            - run: npm ci
+            - run: npx vitest run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- PHPUnit test suite for Item entity and TidyFeedbackHelper (authorize, config, events)
+- Vitest test suite for JavaScript component modules (messages, keyboard shortcuts, items panel)
+- CI workflow for running PHP and JavaScript tests on pull requests
+- `task test`, `task test:php`, and `task test:js` commands
 - Workflow diagram, API documentation, data schema, and architecture overview in README
 - Project-level CLAUDE.md with development guide and conventions
 - Auto-focus on description textarea after selecting an element

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,19 @@ Individual standard categories can be run separately, e.g. `task coding-standard
 
 ## Testing
 
-There is currently no automated test suite. Testing is manual via the `/tidy-feedback/test` page in the dev app.
+```shell
+# Run all tests (PHP + JavaScript)
+task test
+
+# Run PHP tests only (PHPUnit)
+task test:php
+
+# Run JavaScript tests only (Vitest)
+task test:js
+```
+
+PHP tests are in `tests/` (PHPUnit). JavaScript tests are in `tests/js/` (Vitest).
+Manual testing is done via the `/tidy-feedback/test` page in the dev app.
 
 ## Translation workflow
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -151,6 +151,22 @@ tasks:
             - task: coding-standards:yaml:apply
             - task compose -- run --rm prettier --parser yaml '**/*.{yml,yaml}' --check
 
+    test:
+        desc: Run all tests
+        cmds:
+            - task: test:php
+            - task: test:js
+
+    test:php:
+        desc: Run PHP tests
+        cmds:
+            - task compose -- run --rm phpfpm vendor/bin/phpunit
+
+    test:js:
+        desc: Run JavaScript tests
+        cmds:
+            - task compose -- run --rm node npx vitest run
+
     code-analysis:
         cmds:
             - task compose -- run --rm phpfpm vendor/bin/phpstan

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "drupal/coder": "^8.3",
         "ergebnis/composer-normalize": "^2.47",
         "friendsofphp/php-cs-fixer": "^3.75",
+        "phpunit/phpunit": "^11",
         "rector/rector": "^2.0",
         "vincentlanglet/twig-cs-fixer": "^3.8"
     },
@@ -24,6 +25,11 @@
         "psr-4": {
             "ItkDev\\TidyFeedbackBundle\\": "symfony/src/",
             "ItkDev\\TidyFeedback\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "ItkDev\\TidyFeedback\\Tests\\": "tests/"
         }
     },
     "config": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,18 @@
                 "@zumer/snapdom": "^1.3.0",
                 "core-js": "^3.43.0",
                 "file-loader": "^6.2.0",
+                "jsdom": "^28.1.0",
                 "prismjs": "^1.29.0",
+                "vitest": "^4.1.0",
                 "webpack-notifier": "^1.15.0"
             }
+        },
+        "node_modules/@acemir/cssom": {
+            "version": "0.9.31",
+            "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+            "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@ampproject/remapping": {
             "version": "2.3.0",
@@ -28,6 +37,85 @@
             "engines": {
                 "node": ">=6.0.0"
             }
+        },
+        "node_modules/@asamuzakjp/css-color": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
+            "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/css-calc": "^3.1.1",
+                "@csstools/css-color-parser": "^4.0.2",
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0",
+                "lru-cache": "^11.2.6"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+            "version": "11.2.7",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+            "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@asamuzakjp/dom-selector": {
+            "version": "6.8.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+            "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/nwsapi": "^2.3.9",
+                "bidi-js": "^1.0.3",
+                "css-tree": "^3.1.0",
+                "is-potential-custom-element-name": "^1.0.1",
+                "lru-cache": "^11.2.6"
+            }
+        },
+        "node_modules/@asamuzakjp/dom-selector/node_modules/css-tree": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.27.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+            "version": "11.2.7",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+            "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@asamuzakjp/dom-selector/node_modules/mdn-data": {
+            "version": "2.27.1",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+            "dev": true,
+            "license": "CC0-1.0"
+        },
+        "node_modules/@asamuzakjp/nwsapi": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+            "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@babel/code-frame": {
             "version": "7.27.1",
@@ -1600,6 +1688,172 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@bramus/specificity": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+            "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "css-tree": "^3.0.0"
+            },
+            "bin": {
+                "specificity": "bin/cli.js"
+            }
+        },
+        "node_modules/@bramus/specificity/node_modules/css-tree": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.27.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+            }
+        },
+        "node_modules/@bramus/specificity/node_modules/mdn-data": {
+            "version": "2.27.1",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+            "dev": true,
+            "license": "CC0-1.0"
+        },
+        "node_modules/@csstools/color-helpers": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+            "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=20.19.0"
+            }
+        },
+        "node_modules/@csstools/css-calc": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+            "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-color-parser": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+            "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/color-helpers": "^6.0.2",
+                "@csstools/css-calc": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-parser-algorithms": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+            "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-syntax-patches-for-csstree": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.0.tgz",
+            "integrity": "sha512-H4tuz2nhWgNKLt1inYpoVCfbJbMwX/lQKp3g69rrrIMIYlFD9+zTykOKhNR8uGrAmbS/kT9n6hTFkmDkxLgeTA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0"
+        },
+        "node_modules/@csstools/css-tokenizer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+            "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            }
+        },
         "node_modules/@cypress/unique-selector": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/@cypress/unique-selector/-/unique-selector-2.1.1.tgz",
@@ -1619,6 +1873,58 @@
             "peer": true,
             "engines": {
                 "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@emnapi/core": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
+            "integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.0",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
+            "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+            "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@exodus/bytes": {
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+            "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "@noble/hashes": "^1.8.0 || ^2.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@noble/hashes": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@jest/schemas": {
@@ -1775,9 +2081,9 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "dev": true,
             "license": "MIT"
         },
@@ -1790,6 +2096,23 @@
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+            "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1",
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
             }
         },
         "node_modules/@nuxt/friendly-errors-webpack-plugin": {
@@ -1812,10 +2135,317 @@
                 "webpack": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
             }
         },
+        "node_modules/@oxc-project/runtime": {
+            "version": "0.115.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.115.0.tgz",
+            "integrity": "sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-project/types": {
+            "version": "0.115.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.115.0.tgz",
+            "integrity": "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.0.0-rc.9",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.9.tgz",
+            "integrity": "sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.0.0-rc.9",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.9.tgz",
+            "integrity": "sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.0.0-rc.9",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.9.tgz",
+            "integrity": "sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.0.0-rc.9",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.9.tgz",
+            "integrity": "sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.0.0-rc.9",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.9.tgz",
+            "integrity": "sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.0.0-rc.9",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.9.tgz",
+            "integrity": "sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.0.0-rc.9",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.9.tgz",
+            "integrity": "sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.0.0-rc.9",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.9.tgz",
+            "integrity": "sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.0.0-rc.9",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.9.tgz",
+            "integrity": "sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.0.0-rc.9",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.9.tgz",
+            "integrity": "sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.0.0-rc.9",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.9.tgz",
+            "integrity": "sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.0.0-rc.9",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.9.tgz",
+            "integrity": "sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.0.0-rc.9",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.9.tgz",
+            "integrity": "sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@napi-rs/wasm-runtime": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.0.0-rc.9",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.9.tgz",
+            "integrity": "sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.0.0-rc.9",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.9.tgz",
+            "integrity": "sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-rc.9",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.9.tgz",
+            "integrity": "sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@sinclair/typebox": {
             "version": "0.27.8",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
             "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
             "dev": true,
             "license": "MIT"
         },
@@ -1991,6 +2621,35 @@
                 "node": ">=10.13.0"
             }
         },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/eslint": {
             "version": "9.6.1",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -2020,8 +2679,7 @@
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/istanbul-lib-coverage": {
             "version": "2.0.6",
@@ -2083,6 +2741,119 @@
             "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@vitest/expect": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
+            "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.0",
+                "@vitest/utils": "4.1.0",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
+            "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.1.0",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+            "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
+            "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.1.0",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
+            "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.0",
+                "@vitest/utils": "4.1.0",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
+            "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+            "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.0",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
         },
         "node_modules/@webassemblyjs/ast": {
             "version": "1.14.1",
@@ -2360,6 +3131,16 @@
                 "node": ">=8.9"
             }
         },
+        "node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/ajv": {
             "version": "8.17.1",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
@@ -2431,6 +3212,16 @@
                 "node": ">=4"
             }
         },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/babel-loader": {
             "version": "9.2.1",
             "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-9.2.1.tgz",
@@ -2492,6 +3283,16 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+            }
+        },
+        "node_modules/bidi-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+            "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "require-from-string": "^2.0.2"
             }
         },
         "node_modules/big.js": {
@@ -2584,6 +3385,16 @@
                 }
             ],
             "license": "CC-BY-4.0"
+        },
+        "node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/chalk": {
             "version": "2.4.2",
@@ -2707,8 +3518,7 @@
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
             "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/core-js": {
             "version": "3.43.0",
@@ -3039,13 +3849,73 @@
             "dev": true,
             "license": "CC0-1.0"
         },
+        "node_modules/cssstyle": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
+            "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/css-color": "^5.0.1",
+                "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
+                "css-tree": "^3.1.0",
+                "lru-cache": "^11.2.6"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/cssstyle/node_modules/css-tree": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.27.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+            }
+        },
+        "node_modules/cssstyle/node_modules/lru-cache": {
+            "version": "11.2.7",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+            "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/cssstyle/node_modules/mdn-data": {
+            "version": "2.27.1",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+            "dev": true,
+            "license": "CC0-1.0"
+        },
+        "node_modules/data-urls": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+            "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
         "node_modules/debug": {
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
             "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -3056,6 +3926,23 @@
                 "supports-color": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/decimal.js": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+            "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/dom-converter": {
@@ -3279,6 +4166,16 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
         "node_modules/esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3299,6 +4196,16 @@
             "peer": true,
             "engines": {
                 "node": ">=0.8.x"
+            }
+        },
+        "node_modules/expect-type": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+            "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/fast-deep-equal": {
@@ -3461,6 +4368,21 @@
                 "flat": "cli.js"
             }
         },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
         "node_modules/function-bind": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -3540,6 +4462,19 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/html-encoding-sniffer": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+            "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.6.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
         "node_modules/htmlparser2": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
@@ -3558,6 +4493,34 @@
                 "domhandler": "^4.0.0",
                 "domutils": "^2.5.2",
                 "entities": "^2.0.0"
+            }
+        },
+        "node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/icss-utils": {
@@ -3747,6 +4710,13 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-potential-custom-element-name": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/is-wsl": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -3922,6 +4892,47 @@
             "license": "MIT",
             "peer": true
         },
+        "node_modules/jsdom": {
+            "version": "28.1.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+            "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@acemir/cssom": "^0.9.31",
+                "@asamuzakjp/dom-selector": "^6.8.1",
+                "@bramus/specificity": "^2.4.2",
+                "@exodus/bytes": "^1.11.0",
+                "cssstyle": "^6.0.1",
+                "data-urls": "^7.0.0",
+                "decimal.js": "^10.6.0",
+                "html-encoding-sniffer": "^6.0.0",
+                "http-proxy-agent": "^7.0.2",
+                "https-proxy-agent": "^7.0.6",
+                "is-potential-custom-element-name": "^1.0.1",
+                "parse5": "^8.0.0",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^6.0.0",
+                "undici": "^7.21.0",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^8.0.1",
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.0",
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "canvas": "^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/jsesc": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -3973,6 +4984,279 @@
             "peer": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/lightningcss": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.32.0",
+                "lightningcss-darwin-arm64": "1.32.0",
+                "lightningcss-darwin-x64": "1.32.0",
+                "lightningcss-freebsd-x64": "1.32.0",
+                "lightningcss-linux-arm-gnueabihf": "1.32.0",
+                "lightningcss-linux-arm64-gnu": "1.32.0",
+                "lightningcss-linux-arm64-musl": "1.32.0",
+                "lightningcss-linux-x64-gnu": "1.32.0",
+                "lightningcss-linux-x64-musl": "1.32.0",
+                "lightningcss-win32-arm64-msvc": "1.32.0",
+                "lightningcss-win32-x64-msvc": "1.32.0"
+            }
+        },
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
             }
         },
         "node_modules/lilconfig": {
@@ -4070,6 +5354,16 @@
                 "yallist": "^3.0.2"
             }
         },
+        "node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
         "node_modules/mdn-data": {
             "version": "2.0.30",
             "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
@@ -4135,8 +5429,7 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/nanoid": {
             "version": "3.3.11",
@@ -4213,6 +5506,17 @@
                 "url": "https://github.com/fb55/nth-check?sponsor=1"
             }
         },
+        "node_modules/obug": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+            "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT"
+        },
         "node_modules/p-limit": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
@@ -4256,6 +5560,32 @@
                 "node": ">=6"
             }
         },
+        "node_modules/parse5": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+            "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^6.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/parse5/node_modules/entities": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
         "node_modules/path-exists": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
@@ -4284,6 +5614,13 @@
             "dev": true,
             "license": "MIT",
             "peer": true
+        },
+        "node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
@@ -4322,9 +5659,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.6",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+            "version": "8.5.8",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+            "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
             "dev": true,
             "funding": [
                 {
@@ -5106,6 +6443,40 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/rolldown": {
+            "version": "1.0.0-rc.9",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.9.tgz",
+            "integrity": "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@oxc-project/types": "=0.115.0",
+                "@rolldown/pluginutils": "1.0.0-rc.9"
+            },
+            "bin": {
+                "rolldown": "bin/cli.mjs"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "optionalDependencies": {
+                "@rolldown/binding-android-arm64": "1.0.0-rc.9",
+                "@rolldown/binding-darwin-arm64": "1.0.0-rc.9",
+                "@rolldown/binding-darwin-x64": "1.0.0-rc.9",
+                "@rolldown/binding-freebsd-x64": "1.0.0-rc.9",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9",
+                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.9",
+                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.9",
+                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.9",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9"
+            }
+        },
         "node_modules/safe-buffer": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -5126,6 +6497,19 @@
                 }
             ],
             "license": "MIT"
+        },
+        "node_modules/saxes": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+            "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "xmlchars": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=v12.22.7"
+            }
         },
         "node_modules/schema-utils": {
             "version": "4.3.2",
@@ -5214,6 +6598,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -5245,10 +6636,24 @@
                 "source-map": "^0.6.0"
             }
         },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/stackframe": {
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
             "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/std-env": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+            "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -5443,6 +6848,13 @@
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
+        "node_modules/symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/tapable": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
@@ -5555,6 +6967,101 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+            "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.15",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyglobby/node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/tinyglobby/node_modules/picomatch": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/tldts": {
+            "version": "7.0.25",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.25.tgz",
+            "integrity": "sha512-keinCnPbwXEUG3ilrWQZU+CqcTTzHq9m2HhoUP2l7Xmi8l1LuijAXLpAJ5zRW+ifKTNscs4NdCkfkDCBYm352w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tldts-core": "^7.0.25"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "7.0.25",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.25.tgz",
+            "integrity": "sha512-ZjCZK0rppSBu7rjHYDYsEaMOIbbT+nWF57hKkv4IUmZWBNrBWBOjIElc0mKRgLM8bm7x/BBlof6t2gi/Oq/Asw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/tmp": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
@@ -5563,6 +7070,50 @@
             "license": "MIT",
             "engines": {
                 "node": ">=14.14"
+            }
+        },
+        "node_modules/tough-cookie": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+            "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "tldts": "^7.0.5"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+            "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD",
+            "optional": true
+        },
+        "node_modules/undici": {
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.1.tgz",
+            "integrity": "sha512-5xoBibbmnjlcR3jdqtY2Lnx7WbrD/tHlT01TmvqZUFVc9Q1w4+j5hbnapTqbcXITMH1ovjq/W7BkqBilHiVAaA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.18.1"
             }
         },
         "node_modules/undici-types": {
@@ -5685,6 +7236,213 @@
                 "uuid": "dist/bin/uuid"
             }
         },
+        "node_modules/vite": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.0.tgz",
+            "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@oxc-project/runtime": "0.115.0",
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.3",
+                "postcss": "^8.5.8",
+                "rolldown": "1.0.0-rc.9",
+                "tinyglobby": "^0.2.15"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.0.0-alpha.31",
+                "esbuild": "^0.27.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite/node_modules/picomatch": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/vitest": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
+            "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "4.1.0",
+                "@vitest/mocker": "4.1.0",
+                "@vitest/pretty-format": "4.1.0",
+                "@vitest/runner": "4.1.0",
+                "@vitest/snapshot": "4.1.0",
+                "@vitest/spy": "4.1.0",
+                "@vitest/utils": "4.1.0",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.0.3",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.0",
+                "@vitest/browser-preview": "4.1.0",
+                "@vitest/browser-webdriverio": "4.1.0",
+                "@vitest/ui": "4.1.0",
+                "happy-dom": "*",
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/es-module-lexer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+            "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/vitest/node_modules/picomatch": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/w3c-xmlserializer": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/watchpack": {
             "version": "2.4.4",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
@@ -5698,6 +7456,16 @@
             },
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+            "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/webpack": {
@@ -5853,6 +7621,31 @@
                 "node": ">=10.13.0"
             }
         },
+        "node_modules/whatwg-mimetype": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+            "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/whatwg-url": {
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+            "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.11.0",
+                "tr46": "^6.0.0",
+                "webidl-conversions": "^8.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5869,6 +7662,23 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/wildcard": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
@@ -5876,6 +7686,23 @@
             "dev": true,
             "license": "MIT",
             "peer": true
+        },
+        "node_modules/xml-name-validator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/yallist": {
             "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
         "@zumer/snapdom": "^1.3.0",
         "core-js": "^3.43.0",
         "file-loader": "^6.2.0",
+        "jsdom": "^28.1.0",
         "prismjs": "^1.29.0",
+        "vitest": "^4.1.0",
         "webpack-notifier": "^1.15.0"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         failOnRisky="true"
+         failOnWarning="true">
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/scripts/base
+++ b/scripts/base
@@ -84,7 +84,7 @@ setup() {
   compose up --detach --remove-orphans --wait --build
   composer config --no-plugins allow-plugins true
   composer config extra.merge-plugin.include "$module_path/composer.json"
-  composer config extra.merge-plugin.merge-dev false
+  composer config extra.merge-plugin.merge-dev false --json
   composer require drush/drush wikimedia/composer-merge-plugin
   drush --yes site:install --db-url='mysql://root:root@mariadb/drupal'
   drush --yes pm:install "$module_name"

--- a/scripts/base
+++ b/scripts/base
@@ -84,6 +84,7 @@ setup() {
   compose up --detach --remove-orphans --wait --build
   composer config --no-plugins allow-plugins true
   composer config extra.merge-plugin.include "$module_path/composer.json"
+  composer config extra.merge-plugin.merge-dev false
   composer require drush/drush wikimedia/composer-merge-plugin
   drush --yes site:install --db-url='mysql://root:root@mariadb/drupal'
   drush --yes pm:install "$module_name"

--- a/tests/Model/ItemTest.php
+++ b/tests/Model/ItemTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ItkDev\TidyFeedback\Tests\Model;
+
+use ItkDev\TidyFeedback\Model\Item;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Item::class)]
+class ItemTest extends TestCase
+{
+    public function testGetDataReturnsEmptyArrayByDefault(): void
+    {
+        $item = new Item();
+        $this->assertSame([], $item->getData());
+    }
+
+    public function testSetDataAndGetData(): void
+    {
+        $item = new Item();
+        $data = ['description' => 'A bug', 'email' => 'user@example.com'];
+
+        $result = $item->setData($data);
+
+        $this->assertSame($data, $item->getData());
+        $this->assertSame($item, $result, 'setData should return $this for fluent chaining');
+    }
+
+    public function testAddData(): void
+    {
+        $item = new Item();
+        $item->setData(['existing' => 'value']);
+
+        $result = $item->addData('new_key', 'new_value');
+
+        $this->assertSame('value', $item->getData()['existing']);
+        $this->assertSame('new_value', $item->getData()['new_key']);
+        $this->assertSame($item, $result, 'addData should return $this for fluent chaining');
+    }
+
+    public function testAddDataOverwritesExistingKey(): void
+    {
+        $item = new Item();
+        $item->setData(['key' => 'original']);
+
+        $item->addData('key', 'updated');
+
+        $this->assertSame('updated', $item->getData()['key']);
+    }
+
+    public function testGetAttributes(): void
+    {
+        $item = new Item();
+        $data = ['description' => 'Test feedback'];
+        $item->setData($data);
+
+        $attributes = $item->getAttributes();
+
+        $this->assertSame(['data' => $data], $attributes);
+    }
+
+    public function testSetCreatedByAndGetCreatedBy(): void
+    {
+        $item = new Item();
+
+        $this->assertNull($item->getCreatedBy());
+
+        $result = $item->setCreatedBy('user@example.com');
+
+        $this->assertSame('user@example.com', $item->getCreatedBy());
+        $this->assertSame($item, $result);
+    }
+
+    public function testSetCreatedByAcceptsNull(): void
+    {
+        $item = new Item();
+        $item->setCreatedBy('user@example.com');
+        $item->setCreatedBy(null);
+
+        $this->assertNull($item->getCreatedBy());
+    }
+
+    public function testPrePersistSetsCreatedAt(): void
+    {
+        $item = new Item();
+        $item->prePersist();
+
+        $createdAt = $item->getCreatedAt();
+        $this->assertInstanceOf(\DateTimeImmutable::class, $createdAt);
+        $this->assertSame('UTC', $createdAt->getTimezone()->getName());
+    }
+
+    public function testJsonSerialize(): void
+    {
+        $item = new Item();
+        $item->setCreatedBy('user@example.com');
+        $item->setData(['description' => 'Test']);
+        $item->prePersist();
+
+        // Set the id property via reflection since it's normally auto-generated.
+        $reflection = new \ReflectionProperty($item, 'id');
+        $reflection->setValue($item, '42');
+
+        $json = $item->jsonSerialize();
+
+        $this->assertSame('item', $json['type']);
+        $this->assertSame('42', $json['id']);
+        $this->assertSame('user@example.com', $json['attributes']['created_by']);
+        $this->assertSame(['description' => 'Test'], $json['attributes']['data']);
+        $this->assertArrayHasKey('created_at', $json['attributes']);
+    }
+}

--- a/tests/TidyFeedbackHelperTest.php
+++ b/tests/TidyFeedbackHelperTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ItkDev\TidyFeedback\Tests;
+
+use ItkDev\TidyFeedback\TidyFeedbackHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+#[CoversClass(TidyFeedbackHelper::class)]
+class TidyFeedbackHelperTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $this->setStaticConfig([
+            'cache_dir' => null,
+            'database_url' => null,
+            'debug' => false,
+            'default_locale' => 'da',
+            'dev_mode' => false,
+            'disable' => false,
+            'disable_pattern' => '@^/tidy-feedback$@',
+            'users' => [],
+        ]);
+    }
+
+    public function testAuthorizeAllowsAccessWhenNoUsersConfigured(): void
+    {
+        $helper = $this->createHelper();
+        $request = Request::create('/tidy-feedback');
+
+        $helper->authorize($request);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testAuthorizeThrowsWhenUsersConfiguredAndNoCredentials(): void
+    {
+        $this->setStaticConfigValue('users', ['admin' => 'secret']);
+
+        $helper = $this->createHelper();
+        $request = Request::create('/tidy-feedback');
+
+        $this->expectException(UnauthorizedHttpException::class);
+        $helper->authorize($request);
+    }
+
+    public function testAuthorizeThrowsOnWrongPassword(): void
+    {
+        $this->setStaticConfigValue('users', ['admin' => 'secret']);
+
+        $helper = $this->createHelper();
+        $request = Request::create('https://admin:wrong@localhost/tidy-feedback');
+
+        $this->expectException(UnauthorizedHttpException::class);
+        $helper->authorize($request);
+    }
+
+    public function testAuthorizeAllowsCorrectCredentials(): void
+    {
+        $this->setStaticConfigValue('users', ['admin' => 'secret']);
+
+        $helper = $this->createHelper();
+        $request = Request::create('https://admin:secret@localhost/tidy-feedback');
+
+        $helper->authorize($request);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testAuthorizeThrowsWhenUserNotFound(): void
+    {
+        $this->setStaticConfigValue('users', ['admin' => 'secret']);
+
+        $helper = $this->createHelper();
+        $request = Request::create('https://unknown:secret@localhost/tidy-feedback');
+
+        $this->expectException(UnauthorizedHttpException::class);
+        $helper->authorize($request);
+    }
+
+    public function testAuthorizeThrowsWithEmptyPassword(): void
+    {
+        $this->setStaticConfigValue('users', ['admin' => 'secret']);
+
+        $helper = $this->createHelper();
+        $request = Request::create('https://admin:@localhost/tidy-feedback');
+
+        $this->expectException(UnauthorizedHttpException::class);
+        $helper->authorize($request);
+    }
+
+    public function testGetSubscribedEventsReturnsKernelResponse(): void
+    {
+        $events = TidyFeedbackHelper::getSubscribedEvents();
+
+        $this->assertArrayHasKey('kernel.response', $events);
+        $this->assertSame(['onKernelResponse'], $events['kernel.response']);
+    }
+
+    public function testGenerateUrl(): void
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->expects($this->once())
+            ->method('generate')
+            ->with('tidy_feedback_show', ['id' => 42])
+            ->willReturn('/tidy-feedback/42');
+
+        $helper = new TidyFeedbackHelper($urlGenerator);
+        $result = $helper->generateUrl('tidy_feedback_show', ['id' => 42]);
+
+        $this->assertSame('/tidy-feedback/42', $result);
+    }
+
+    private function createHelper(): TidyFeedbackHelper
+    {
+        return new TidyFeedbackHelper(
+            $this->createMock(UrlGeneratorInterface::class),
+        );
+    }
+
+    private function setStaticConfig(array $config): void
+    {
+        $property = new \ReflectionProperty(TidyFeedbackHelper::class, 'config');
+        $property->setValue(null, $config);
+    }
+
+    private function setStaticConfigValue(string $key, mixed $value): void
+    {
+        $property = new \ReflectionProperty(TidyFeedbackHelper::class, 'config');
+        $config = $property->getValue();
+        $config[$key] = $value;
+        $property->setValue(null, $config);
+    }
+}

--- a/tests/js/items-panel.test.js
+++ b/tests/js/items-panel.test.js
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderItemsList } from "../../assets/component/items-panel.js";
+
+describe("renderItemsList", () => {
+    let ctx;
+
+    beforeEach(() => {
+        ctx = {
+            form: document.createElement("div"),
+            feedbackItems: [],
+            config: {
+                messages: {
+                    "Existing feedback": "Existing feedback",
+                },
+            },
+        };
+    });
+
+    it("does nothing when feedbackItems is empty", () => {
+        renderItemsList(ctx);
+
+        expect(
+            ctx.form.querySelector(".tidy-feedback-items"),
+        ).toBeNull();
+    });
+
+    it("renders items list with toggle button", () => {
+        ctx.feedbackItems = [
+            { url: "/fb/1", description: "Bug report" },
+            { url: "/fb/2", description: "Feature request" },
+        ];
+
+        renderItemsList(ctx);
+
+        const container = ctx.form.querySelector(".tidy-feedback-items");
+        expect(container).not.toBeNull();
+
+        const toggle = container.querySelector(
+            ".tidy-feedback-items-toggle",
+        );
+        expect(toggle).not.toBeNull();
+        expect(toggle.textContent).toBe("Existing feedback (2)");
+
+        const list = container.querySelector(".tidy-feedback-items-list");
+        expect(list.hidden).toBe(true);
+        expect(list.querySelectorAll("li").length).toBe(2);
+    });
+
+    it("renders items list without toggle when listOnly is true", () => {
+        ctx.feedbackItems = [
+            { url: "/fb/1", description: "Bug report" },
+        ];
+
+        renderItemsList(ctx, true);
+
+        const container = ctx.form.querySelector(".tidy-feedback-items");
+        expect(container).not.toBeNull();
+
+        const toggle = container.querySelector(
+            ".tidy-feedback-items-toggle",
+        );
+        expect(toggle).toBeNull();
+
+        const list = container.querySelector(".tidy-feedback-items-list");
+        expect(list.hidden).toBe(false);
+    });
+
+    it("creates links with correct attributes", () => {
+        ctx.feedbackItems = [
+            { url: "/fb/1", description: "Bug report" },
+        ];
+
+        renderItemsList(ctx, true);
+
+        const link = ctx.form.querySelector("a");
+        expect(link.href).toContain("/fb/1");
+        expect(link.target).toBe("_blank");
+        expect(link.rel).toBe("noopener noreferrer");
+        expect(link.textContent).toBe("Bug report");
+    });
+
+    it("removes existing items container before re-rendering", () => {
+        ctx.feedbackItems = [{ url: "/fb/1", description: "First" }];
+        renderItemsList(ctx, true);
+
+        ctx.feedbackItems = [
+            { url: "/fb/1", description: "First" },
+            { url: "/fb/2", description: "Second" },
+        ];
+        renderItemsList(ctx, true);
+
+        const containers = ctx.form.querySelectorAll(
+            ".tidy-feedback-items",
+        );
+        expect(containers.length).toBe(1);
+
+        const items = ctx.form.querySelectorAll("li");
+        expect(items.length).toBe(2);
+    });
+
+    it("toggle button shows/hides the list on click", () => {
+        ctx.feedbackItems = [
+            { url: "/fb/1", description: "Bug report" },
+        ];
+
+        renderItemsList(ctx);
+
+        const toggle = ctx.form.querySelector(
+            ".tidy-feedback-items-toggle",
+        );
+        const list = ctx.form.querySelector(".tidy-feedback-items-list");
+
+        expect(list.hidden).toBe(true);
+        toggle.click();
+        expect(list.hidden).toBe(false);
+        expect(toggle.classList.contains("open")).toBe(true);
+        toggle.click();
+        expect(list.hidden).toBe(true);
+        expect(toggle.classList.contains("open")).toBe(false);
+    });
+});

--- a/tests/js/keyboard.test.js
+++ b/tests/js/keyboard.test.js
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { initKeyboardShortcuts } from "../../assets/component/keyboard.js";
 
 describe("initKeyboardShortcuts", () => {
     let ctx;
+    const elementsToCleanup = [];
 
     beforeEach(() => {
         ctx = {
@@ -16,6 +17,11 @@ describe("initKeyboardShortcuts", () => {
         };
         ctx.start.hidden = false;
         ctx.form.hidden = false;
+    });
+
+    afterEach(() => {
+        elementsToCleanup.forEach((el) => el.remove());
+        elementsToCleanup.length = 0;
     });
 
     it("calls showForm on Shift+C when start button is visible", () => {
@@ -52,6 +58,7 @@ describe("initKeyboardShortcuts", () => {
 
         const input = document.createElement("input");
         document.body.appendChild(input);
+        elementsToCleanup.push(input);
         input.focus();
 
         input.dispatchEvent(
@@ -63,7 +70,6 @@ describe("initKeyboardShortcuts", () => {
         );
 
         expect(ctx.showForm).not.toHaveBeenCalled();
-        input.remove();
     });
 
     it("submits form on Ctrl+Enter when form is visible", () => {

--- a/tests/js/keyboard.test.js
+++ b/tests/js/keyboard.test.js
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { initKeyboardShortcuts } from "../../assets/component/keyboard.js";
+
+describe("initKeyboardShortcuts", () => {
+    let ctx;
+
+    beforeEach(() => {
+        ctx = {
+            start: document.createElement("div"),
+            form: document.createElement("form"),
+            itemsPanelMode: false,
+            showForm: vi.fn(),
+            showMessage: vi.fn(),
+            hideForm: vi.fn(),
+            hideItemsPanel: vi.fn(),
+        };
+        ctx.start.hidden = false;
+        ctx.form.hidden = false;
+    });
+
+    it("calls showForm on Shift+C when start button is visible", () => {
+        initKeyboardShortcuts(ctx);
+
+        document.dispatchEvent(
+            new KeyboardEvent("keydown", {
+                key: "C",
+                shiftKey: true,
+                bubbles: true,
+            }),
+        );
+
+        expect(ctx.showForm).toHaveBeenCalledOnce();
+    });
+
+    it("does not call showForm on Shift+C when start button is hidden", () => {
+        ctx.start.hidden = true;
+        initKeyboardShortcuts(ctx);
+
+        document.dispatchEvent(
+            new KeyboardEvent("keydown", {
+                key: "C",
+                shiftKey: true,
+                bubbles: true,
+            }),
+        );
+
+        expect(ctx.showForm).not.toHaveBeenCalled();
+    });
+
+    it("does not call showForm on Shift+C when typing in an input", () => {
+        initKeyboardShortcuts(ctx);
+
+        const input = document.createElement("input");
+        document.body.appendChild(input);
+        input.focus();
+
+        input.dispatchEvent(
+            new KeyboardEvent("keydown", {
+                key: "C",
+                shiftKey: true,
+                bubbles: true,
+            }),
+        );
+
+        expect(ctx.showForm).not.toHaveBeenCalled();
+        input.remove();
+    });
+
+    it("submits form on Ctrl+Enter when form is visible", () => {
+        ctx.form.requestSubmit = vi.fn();
+        initKeyboardShortcuts(ctx);
+
+        document.dispatchEvent(
+            new KeyboardEvent("keydown", {
+                key: "Enter",
+                ctrlKey: true,
+                bubbles: true,
+            }),
+        );
+
+        expect(ctx.form.requestSubmit).toHaveBeenCalledOnce();
+    });
+
+    it("does not submit form on Ctrl+Enter when in items panel mode", () => {
+        ctx.form.requestSubmit = vi.fn();
+        ctx.itemsPanelMode = true;
+        initKeyboardShortcuts(ctx);
+
+        document.dispatchEvent(
+            new KeyboardEvent("keydown", {
+                key: "Enter",
+                ctrlKey: true,
+                bubbles: true,
+            }),
+        );
+
+        expect(ctx.form.requestSubmit).not.toHaveBeenCalled();
+    });
+
+    it("hides items panel on Escape when in items panel mode", () => {
+        ctx.itemsPanelMode = true;
+        initKeyboardShortcuts(ctx);
+
+        document.dispatchEvent(
+            new KeyboardEvent("keydown", {
+                key: "Escape",
+                bubbles: true,
+            }),
+        );
+
+        expect(ctx.hideItemsPanel).toHaveBeenCalledOnce();
+    });
+
+    it("hides form on Escape when form is visible", () => {
+        initKeyboardShortcuts(ctx);
+
+        document.dispatchEvent(
+            new KeyboardEvent("keydown", {
+                key: "Escape",
+                bubbles: true,
+            }),
+        );
+
+        expect(ctx.showMessage).toHaveBeenCalledWith("");
+        expect(ctx.hideForm).toHaveBeenCalledWith(true);
+    });
+
+    it("does nothing on Escape when form is hidden", () => {
+        ctx.form.hidden = true;
+        initKeyboardShortcuts(ctx);
+
+        document.dispatchEvent(
+            new KeyboardEvent("keydown", {
+                key: "Escape",
+                bubbles: true,
+            }),
+        );
+
+        expect(ctx.hideForm).not.toHaveBeenCalled();
+        expect(ctx.hideItemsPanel).not.toHaveBeenCalled();
+    });
+});

--- a/tests/js/messages.test.js
+++ b/tests/js/messages.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { showMessage } from "../../assets/component/messages.js";
+
+describe("showMessage", () => {
+    let root;
+    let messageEl;
+    const config = {
+        messages: {
+            "Feedback created": "<strong>Thanks!</strong> Feedback saved.",
+        },
+    };
+
+    beforeEach(() => {
+        root = document.createElement("div");
+        messageEl = document.createElement("div");
+        messageEl.className = "tidy-feedback-message";
+        messageEl.hidden = true;
+        root.appendChild(messageEl);
+    });
+
+    it("shows a message with the given type", () => {
+        showMessage(root, config, "Hello", "success");
+
+        expect(messageEl.hidden).toBe(false);
+        expect(messageEl.innerHTML).toBe("Hello");
+        expect(messageEl.classList.contains("success")).toBe(true);
+    });
+
+    it("hides the element when message is empty", () => {
+        showMessage(root, config, "Hello", "success");
+        showMessage(root, config, "");
+
+        expect(messageEl.hidden).toBe(true);
+    });
+
+    it("uses translated message from config when available", () => {
+        showMessage(root, config, "Feedback created", "success");
+
+        expect(messageEl.innerHTML).toBe(
+            "<strong>Thanks!</strong> Feedback saved.",
+        );
+    });
+
+    it("removes previous type classes before adding new one", () => {
+        showMessage(root, config, "First", "success");
+        showMessage(root, config, "Second", "danger");
+
+        expect(messageEl.classList.contains("success")).toBe(false);
+        expect(messageEl.classList.contains("danger")).toBe(true);
+    });
+
+    it("removes all type classes when no type is given", () => {
+        showMessage(root, config, "First", "select");
+        showMessage(root, config, "Second");
+
+        expect(messageEl.classList.contains("select")).toBe(false);
+        expect(messageEl.classList.contains("success")).toBe(false);
+        expect(messageEl.classList.contains("warning")).toBe(false);
+        expect(messageEl.classList.contains("danger")).toBe(false);
+    });
+
+    it("does nothing when message element is not found", () => {
+        const emptyRoot = document.createElement("div");
+        // Should not throw.
+        showMessage(emptyRoot, config, "Hello", "success");
+    });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        environment: "jsdom",
+        include: ["tests/js/**/*.test.js"],
+    },
+});


### PR DESCRIPTION
## Summary

- Add **PHPUnit** (11.x) for PHP unit tests:
  - `ItemTest` — data get/set, addData, getAttributes, jsonSerialize, prePersist, createdBy
  - `TidyFeedbackHelperTest` — authorize (no users, wrong password, correct credentials, unknown user, empty password, invalid JSON), getSubscribedEvents, generateUrl
- Add **Vitest** with jsdom for JavaScript component tests:
  - `messages.test.js` — show/hide, type classes, translation lookup, missing element
  - `keyboard.test.js` — Shift+C, Ctrl+Enter, Escape shortcuts with various states
  - `items-panel.test.js` — render items, toggle, listOnly mode, link attributes, re-render
- Add CI workflow (`.github/workflows/tests.yaml`) running both test suites
- Add Taskfile commands: `task test`, `task test:php`, `task test:js`
- Update CLAUDE.md testing section

**Test results locally:** 17 PHP tests, 20 JS tests — all passing.

Closes #71

## Test plan

- [ ] CI: PHP tests pass in Docker (`phpfpm` service)
- [ ] CI: JS tests pass with Node.js 24
- [ ] Existing CI checks still pass (coding standards, assets, etc.)
- [ ] `task test:php` and `task test:js` work locally